### PR TITLE
Switch to hydra uri

### DIFF
--- a/rhsda/__init__.py
+++ b/rhsda/__init__.py
@@ -180,7 +180,7 @@ class ApiClient:
 
     def __init__(self, logLevel='notice'):
         self.cfg = Namespace()
-        self.cfg.apiUrl = 'https://access.redhat.com/labs/securitydataapi'
+        self.cfg.apiUrl = 'https://access.redhat.com/hydra/rest/securitydata'
         logger.setLevel(logLevel.upper())
 
     def _get_terminal_width(self):


### PR DESCRIPTION
The original api url no longer is functional(or allowing access). Move to the Hydra pathing, which continues to provide access with what appears to be the same API.

requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://access.redhat.com/labs/securitydataapi/cve.json?package=bash